### PR TITLE
Update SCIM_tests_for_Runscope.json

### DIFF
--- a/SCIM_tests_for_Runscope.json
+++ b/SCIM_tests_for_Runscope.json
@@ -114,9 +114,9 @@
           "source": "response_status"
         }, 
         {
-          "comparison": "not_empty", 
-          "property": "Resources", 
-          "value": null, 
+          "comparison": "does_not_contain", 
+          "property": "", 
+          "value": "Resources", 
           "source": "response_json"
         }, 
         {


### PR DESCRIPTION
The rfc7644 (section 3.4.2) says that the Resources attribute is required if the totalResults is non-zero. If it is zero the attribute should not exist.
