### PR TITLE
use https for api.randomuser (returns 301 for http)

### DIFF
--- a/SCIM_tests_for_Runscope.json
+++ b/SCIM_tests_for_Runscope.json
@@ -137,7 +137,7 @@
       "before_scripts": []
     }, 
     {
-      "url": "http://api.randomuser.me?nat=us,dk,fr,gb", 
+      "url": "https://api.randomuser.me?nat=us,dk,fr,gb",
       "variables": [
         {
           "source": "response_json", 


### PR DESCRIPTION
I was running into following test failure:

<img width="1169" alt="screen shot 2017-09-01 at 1 36 41 pm" src="https://user-images.githubusercontent.com/926828/29987059-316e408c-8f1b-11e7-9880-d065d356e6cd.png">

which this changed fixed.